### PR TITLE
Revert "[chore] Renovate: Update dependency androidx.lifecycle:lifecy…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.8.0"
+lifecycleRuntimeKtx = "2.7.0"
 activityCompose = "1.9.0"
 composeBom = "2024.05.00"
 


### PR DESCRIPTION
…cle-runtime-ktx 2.7.0 to v2.8.0"

This reverts commit 14ac748cfc5c94e80d7bb3ccfc3494252d3332d6.

[chore] Gradle: downgrade lifecycle again