### PR TITLE
Github Actions: force CI to false for Dependency Submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -20,3 +20,5 @@ jobs:
           java-version: '17'
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3
+        env:
+          CI: 'false'


### PR DESCRIPTION
We have solved it in child repo but forgotten to update the parent here.
We don't need CI to involve for the dependentbot to work