### PR TITLE
[feature] App: make the base project default for edge-to-edge

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.GithubCIDemo">
+            android:theme="@style/Theme.GithubCIDemo"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/rwmobi/githubcidemo/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/githubcidemo/MainActivity.kt
@@ -3,23 +3,37 @@ package com.rwmobi.githubcidemo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.rwmobi.githubcidemo.ui.theme.GithubCIDemoTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // allows your app to be edge-to-edge on Android 15 before.
+        enableEdgeToEdge()
+
         setContent {
             GithubCIDemoTheme {
-                // A surface container using the 'background' color from the theme
+                // Android 15+ Will see solid red status bar
+                // and red tinted navigation bar
+                // Pre Android 15 will see tinted navigation bar
+                // BUT status bar is not affected
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .background(color = Color.Red)
+                        .fillMaxSize()
+                        .safeDrawingPadding(),
                     color = MaterialTheme.colorScheme.background
                 ) {
                     Greeting("Android")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # App configurations, not dependencies
 minsdk = "26"
-targetsdk = "34"
+targetsdk = "35"
 compilesdk = "35"
 
 agp = "8.8.0"


### PR DESCRIPTION
Little changes to the default template, so the minimal edge-to-edge code is there to remind us that we SHOULD handle the pointless edge-to-edge changes for pre and pro-Android 15. 