### PR TITLE
Gradle: migrate to kotlinter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
-    alias(libs.plugins.gradle.ktlint)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlinter)
 }
 
 // Configuration
@@ -99,17 +99,8 @@ dependencies {
 
 tasks {
     // copyBaselineProfileAfterBuild()
-    getByPath("preBuild").dependsOn("ktlintFormat")
-}
-
-configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-    android = true
-    ignoreFailures = isRunningOnCI
-    reporters {
-        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.PLAIN)
-        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
-        reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.SARIF)
-    }
+    check { dependsOn("detekt") }
+    preBuild { dependsOn("formatKotlin") }
 }
 
 detekt { parallel = true }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlinx.kover) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.kotlinter) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2025.07.00"
 kover = "0.9.1"
-gradle-ktlint = "13.0.0"
+kotlinter = "5.1.1"
 detekt = "1.23.8"
 
 # App configurations, not dependencies
@@ -40,5 +40,5 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "gradle-ktlint" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }


### PR DESCRIPTION
We've been thinking of migrating out from jlleitschuh's ktlint gradle plugin for a long time, and how here we go.