### PR TITLE
Gradle: fix bundle filename

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -220,9 +220,8 @@ private fun BaseAppModuleExtension.setupSigningAndBuildTypes() {
 
     val timestamp = SimpleDateFormat("yyyyMMdd‑HHmmss").format(Date())
     val baseName = "$productApkName‑${libs.versions.versionName.get()}‑$timestamp"
-    tasks.withType<AbstractArchiveTask>().configureEach {
-        // Bundle output filename
-        archiveBaseName.set(baseName)
+    extensions.configure<BasePluginExtension> {
+        archivesName.set(baseName)
     }
 
     buildTypes {


### PR DESCRIPTION
Fix to correctly set the bundle name which broke the CI pipeline